### PR TITLE
feat: 관리자 태그/영화 통계 기능 추가(Feature/0522)

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminTagController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminTagController.java
@@ -1,8 +1,11 @@
 package com.grepp.smartwatcha.app.controller.web.admin;
 
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageWithUsersDto;
+import com.grepp.smartwatcha.app.model.admin.tag.service.AdminMovieTagJpaService;
 import com.grepp.smartwatcha.app.model.admin.tag.service.AdminTagJpaService;
 import com.grepp.smartwatcha.infra.jpa.entity.TagEntity;
 import com.grepp.smartwatcha.infra.response.PageResponse;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class AdminTagController { // 태그 목록 페이지
 
   private final AdminTagJpaService adminTagJpaService;
+  private final AdminMovieTagJpaService adminMovieTagJpaService;
 
   // 태그 목록 페이지 반환
   // 입력: page(페이지 번호), size(페이지 크기), keyword(검색 키워드, nullable), model(뷰 모델)
@@ -37,6 +41,14 @@ public class AdminTagController { // 태그 목록 페이지
     model.addAttribute("pageResponse", pageResponse);
     model.addAttribute("tags", tags.getContent());
     model.addAttribute("keyword", keyword);
+
+    // 태그별 사용 통계
+    Map<Long, Long> tagUsageMap = adminMovieTagJpaService.getTagUsageCountMap(); // ID 기준
+    model.addAttribute("tagUsageMap", tagUsageMap);
+
+    // 태그별 사용 유저 + 영화
+    Map<Long, AdminTagUsageWithUsersDto> tagUsageDetailsMap = adminMovieTagJpaService.getTagUsageWithUserDetailMap();
+    model.addAttribute("tagUsageDetailsMap", tagUsageDetailsMap);
 
     return "admin/tag/list";
   }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminTagController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminTagController.java
@@ -1,6 +1,6 @@
 package com.grepp.smartwatcha.app.controller.web.admin;
 
-import com.grepp.smartwatcha.app.model.admin.tag.AdminTagJpaService;
+import com.grepp.smartwatcha.app.model.admin.tag.service.AdminTagJpaService;
 import com.grepp.smartwatcha.infra.jpa.entity.TagEntity;
 import com.grepp.smartwatcha.infra.response.PageResponse;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/movie/AdminMovieController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/movie/AdminMovieController.java
@@ -4,10 +4,14 @@ import com.grepp.smartwatcha.app.model.admin.movie.list.dto.AdminMovieListRespon
 import com.grepp.smartwatcha.app.model.admin.movie.list.dto.AdminMovieUpdateRequest;
 import com.grepp.smartwatcha.app.model.admin.movie.list.repository.AdminMovieJpaRepository;
 import com.grepp.smartwatcha.app.model.admin.movie.list.service.AdminMovieJpaService;
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageDto;
+import com.grepp.smartwatcha.app.model.admin.tag.service.AdminMovieTagJpaService;
 import com.grepp.smartwatcha.infra.response.PageResponse;
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +32,7 @@ public class AdminMovieController {
 
   private final AdminMovieJpaRepository adminMovieJpaRepository;
   private final AdminMovieJpaService adminMovieJpaService;
+  private final AdminMovieTagJpaService adminMovieTagJpaService;
 
   /**
    * 영화 목록 조회 (관리자용)
@@ -64,6 +69,20 @@ public class AdminMovieController {
     model.addAttribute("isReleased", isReleased);
     model.addAttribute("fromDate", fromDate);
     model.addAttribute("toDate", toDate);
+
+    // movieId 리스트 추출
+    List<Long> movieIds = movies.getContent().stream()
+        .map(AdminMovieListResponse::getId)
+        .collect(Collectors.toList());
+
+    // 영화 사용자 태그 통계
+    Map<Long, List<AdminTagUsageDto>> tagStatsMap = adminMovieTagJpaService.getTagStatsMapGroupedByMovieIds(movieIds);
+    model.addAttribute("tagStatsMap", tagStatsMap);
+
+    // 영화 사용자 평점평균
+    Map<Long, Double> avgRatingMap = adminMovieJpaService.getAverageRatingByMovieIds(movieIds);
+    model.addAttribute("avgRatingMap", avgRatingMap);
+
 
     return "admin/movie/list";
   }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
@@ -2,7 +2,7 @@ package com.grepp.smartwatcha.app.model.admin;
 
 import com.grepp.smartwatcha.app.model.admin.movie.list.repository.AdminMovieJpaRepository;
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.jpa.UpcomingMovieSyncTimeJpaRepository;
-import com.grepp.smartwatcha.app.model.admin.tag.AdminTagJpaRepository;
+import com.grepp.smartwatcha.app.model.admin.tag.repository.AdminTagJpaRepository;
 import com.grepp.smartwatcha.app.model.admin.user.repository.AdminUserJpaRepository;
 import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
 import com.grepp.smartwatcha.infra.jpa.entity.SyncTimeEntity;

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/dto/AdminMovieListResponse.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/dto/AdminMovieListResponse.java
@@ -1,6 +1,7 @@
 package com.grepp.smartwatcha.app.model.admin.movie.list.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,4 +21,5 @@ public class AdminMovieListResponse {
   private String certification;
   private String overview;
   private boolean updatedRecently;
+  private List<String> tags; // + 사용자 태그 목록
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/repository/AdminMovieRatingJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/repository/AdminMovieRatingJpaRepository.java
@@ -1,0 +1,18 @@
+package com.grepp.smartwatcha.app.model.admin.movie.list.repository;
+
+import com.grepp.smartwatcha.infra.jpa.entity.RatingEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+// Admin 페이지에서 영화별 평균 평점을 조회하기 위한 JPA Repository.
+public interface AdminMovieRatingJpaRepository extends JpaRepository<RatingEntity, Long> {
+
+  // 주어진 영화 ID 목록에 대해 영화별 평균 평점을 조회
+  // @param movieIds 평균 평점을 조회할 영화 ID 목록
+  // @return 각 영화 ID와 해당 영화의 평균 평점을 담은 Object 배열 리스트
+  //         (index 0: movieId, index 1: 평균 평점(Double))
+  @Query("SELECT r.movie.id, AVG(r.score) FROM RatingEntity r WHERE r.movie.id IN :movieIds GROUP BY r.movie.id")
+  List<Object[]> findAverageRatingByMovieIds(@Param("movieIds") List<Long> movieIds);
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/service/AdminMovieJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/service/AdminMovieJpaService.java
@@ -4,6 +4,7 @@ import com.grepp.smartwatcha.app.model.admin.movie.list.dto.AdminMovieListRespon
 import com.grepp.smartwatcha.app.model.admin.movie.list.dto.AdminMovieUpdateRequest;
 import com.grepp.smartwatcha.app.model.admin.movie.list.mapper.AdminMovieMapper;
 import com.grepp.smartwatcha.app.model.admin.movie.list.repository.AdminMovieJpaRepository;
+import com.grepp.smartwatcha.app.model.admin.movie.list.repository.AdminMovieRatingJpaRepository;
 import com.grepp.smartwatcha.infra.error.exceptions.CommonException;
 import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
 import com.grepp.smartwatcha.infra.response.ResponseCode;
@@ -11,6 +12,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminMovieJpaService {
 
   private final AdminMovieJpaRepository adminMovieJpaRepository;
+  private final AdminMovieRatingJpaRepository adminMovieRatingJpaRepository;
 
   // 영화 필터 조회
   // - keyword 가 날짜 범위 형식이면 releaseDate 기준 필터
@@ -114,5 +118,14 @@ public class AdminMovieJpaService {
     MovieEntity movie = adminMovieJpaRepository.findById(id)
         .orElseThrow(() -> new CommonException(ResponseCode.BAD_REQUEST));
     adminMovieJpaRepository.delete(movie);
+  }
+
+  // 영화 평점평균
+  public Map<Long, Double> getAverageRatingByMovieIds(List<Long> movieIds) {
+    List<Object[]> resultList = adminMovieRatingJpaRepository.findAverageRatingByMovieIds(movieIds);
+    return resultList.stream().collect(Collectors.toMap(
+        row -> (Long) row[0],
+        row -> (Double) row[1]
+    ));
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/dto/AdminTagUsageDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/dto/AdminTagUsageDto.java
@@ -1,0 +1,17 @@
+package com.grepp.smartwatcha.app.model.admin.tag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminTagUsageDto { // 태그 사용 통계를 나타내는 DTO
+  private Long tagId;
+  private Long movieId;
+  private String tagName;
+  private Long count;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/dto/AdminTagUsageWithUsersDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/dto/AdminTagUsageWithUsersDto.java
@@ -1,0 +1,18 @@
+package com.grepp.smartwatcha.app.model.admin.tag.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminTagUsageWithUsersDto { // 태그별 유저 상세 사용 내역을 포함한 통계 DTO
+  private Long tagId;
+  private String tagName;
+  private Long usageCount; // 태그 전체 사용 횟수
+  private List<AdminTagUserUsageDto> userUsages; // 해당 태그를 사용한 유저들의 상세 정보 리스트
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/dto/AdminTagUserUsageDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/dto/AdminTagUserUsageDto.java
@@ -1,0 +1,26 @@
+package com.grepp.smartwatcha.app.model.admin.tag.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+public class AdminTagUserUsageDto { // 태그 사용 유저의 영화별 사용 내역을 나타내는 DTO.
+  private Long tagId;
+  private Long userId;
+  private String userName;
+  private Long movieId;
+  private String movieTitle;
+
+  public AdminTagUserUsageDto(Long tagId, Long userId, String userName, Long movieId, String movieTitle) {
+    this.tagId = tagId;
+    this.userId = userId;
+    this.userName = userName;
+    this.movieId = movieId;
+    this.movieTitle = movieTitle;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/repository/AdminMovieTagJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/repository/AdminMovieTagJpaRepository.java
@@ -1,0 +1,42 @@
+package com.grepp.smartwatcha.app.model.admin.tag.repository;
+
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageDto;
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUserUsageDto;
+import com.grepp.smartwatcha.infra.jpa.entity.MovieTagEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+// 관리자 페이지에서 태그 사용 통계 및 유저별 사용 내역을 조회하는 JPA Repository
+public interface AdminMovieTagJpaRepository extends JpaRepository<MovieTagEntity, Long> {
+
+  // 전체 영화-태그 관계에 대한 태그 사용 통계를 조회
+  // @return 태그 ID, 영화 ID, 태그명, 사용 횟수를 포함한 통계 DTO 리스트
+  @Query("SELECT new com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageDto(" +
+      "mt.tag.id, mt.movie.id, mt.tag.name, COUNT(mt)) " +
+      "FROM MovieTagEntity mt " +
+      "GROUP BY mt.tag.id, mt.movie.id, mt.tag.name " +
+      "ORDER BY COUNT(mt) DESC")
+  List<AdminTagUsageDto> findAllTagUsageStats();
+
+  // 특정 태그를 사용한 유저 및 영화 정보를 조회
+  // @param tagId 태그 ID
+  // * @return 유저 ID, 유저 이름, 영화 ID, 영화 제목을 담은 DTO 리스트
+  @Query("SELECT new com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUserUsageDto(mt.tag.id, u.id, u.name, m.id, m.title) " +
+      "FROM MovieTagEntity mt " +
+      "JOIN mt.user u " +
+      "JOIN mt.movie m " +
+      "WHERE mt.tag.id = :tagId")
+  List<AdminTagUserUsageDto> findUserUsageByTagId(@Param("tagId") Long tagId);
+
+  // 주어진 영화 목록에 대해 태그 사용 통계를 조회
+  // @param movieIds 영화 ID 목록
+  // * @return 태그 ID, 영화 ID, 태그명, 사용 횟수를 포함한 통계 DTO 리스트
+  @Query("SELECT new com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageDto(" +
+      "mt.tag.id, mt.movie.id, mt.tag.name, COUNT(mt)) " +
+      "FROM MovieTagEntity mt " +
+      "WHERE mt.movie.id IN :movieIds " +
+      "GROUP BY mt.tag.id, mt.movie.id, mt.tag.name")
+  List<AdminTagUsageDto> findTagStatsByMovieIds(@Param("movieIds") List<Long> movieIds);
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/repository/AdminTagJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/repository/AdminTagJpaRepository.java
@@ -1,4 +1,4 @@
-package com.grepp.smartwatcha.app.model.admin.tag;
+package com.grepp.smartwatcha.app.model.admin.tag.repository;
 
 import com.grepp.smartwatcha.infra.jpa.entity.TagEntity;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/service/AdminMovieTagJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/service/AdminMovieTagJpaService.java
@@ -1,0 +1,65 @@
+package com.grepp.smartwatcha.app.model.admin.tag.service;
+
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageDto;
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUsageWithUsersDto;
+import com.grepp.smartwatcha.app.model.admin.tag.dto.AdminTagUserUsageDto;
+import com.grepp.smartwatcha.app.model.admin.tag.repository.AdminMovieTagJpaRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMovieTagJpaService { // 관리자 페이지에서 태그 관련 통계를 제공하는 서비스 클래스
+
+  private final AdminMovieTagJpaRepository adminMovieTagJpaRepository;
+
+  // 전체 태그별 사용 횟수를 집계하여 Map 으로 반환
+  // @return 태그 ID를 키로 하고 사용 횟수를 값으로 가지는 Map
+  public Map<Long, Long> getTagUsageCountMap(){
+    List<AdminTagUsageDto> usageStats = adminMovieTagJpaRepository.findAllTagUsageStats();
+    return usageStats.stream()
+        .collect(Collectors.toMap(
+            AdminTagUsageDto::getTagId,
+            AdminTagUsageDto::getCount,
+            Long::sum // 동일 태그 ID가 있을 경우 사용 횟수를 합산
+        ));
+  }
+
+  // 전체 태그에 대해 유저별 사용 상세 정보를 포함한 통계를 반환
+  // @return 태그 ID를 키로 하고 상세 정보를 담은 DTO 를 값으로 가지는 Map
+  public Map<Long, AdminTagUsageWithUsersDto> getTagUsageWithUserDetailMap() {
+    List<AdminTagUsageDto> usageStats = adminMovieTagJpaRepository.findAllTagUsageStats();
+
+    Map<Long, AdminTagUsageWithUsersDto> result = new HashMap<>();
+
+    // 각 유저 DTO 에 태그 ID 설정
+    for(AdminTagUsageDto stat : usageStats) {
+      List<AdminTagUserUsageDto> userDetails = adminMovieTagJpaRepository.findUserUsageByTagId(stat.getTagId());
+
+      for(AdminTagUserUsageDto dto : userDetails) {
+        dto.setTagId(stat.getTagId());
+      }
+
+      AdminTagUsageWithUsersDto dto = new AdminTagUsageWithUsersDto(
+          stat.getTagId(),
+          stat.getTagName(),
+          stat.getCount(),
+          userDetails
+      );
+      result.put(stat.getTagId(), dto);
+    }
+    return result;
+  }
+
+  // 여러 영화에 대해 각 영화별 태그 사용 통계를 반환
+  // @param movieIds 영화 ID 리스트
+  // * @return 영화 ID를 키로 하고 태그 사용 통계 리스트를 값으로 가지는 Map
+  public Map<Long, List<AdminTagUsageDto>> getTagStatsMapGroupedByMovieIds(List<Long> movieIds) {
+    List<AdminTagUsageDto> allStats = adminMovieTagJpaRepository.findTagStatsByMovieIds(movieIds);
+    return allStats.stream().collect(Collectors.groupingBy(AdminTagUsageDto::getMovieId));
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/service/AdminTagJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/service/AdminTagJpaService.java
@@ -1,5 +1,6 @@
-package com.grepp.smartwatcha.app.model.admin.tag;
+package com.grepp.smartwatcha.app.model.admin.tag.service;
 
+import com.grepp.smartwatcha.app.model.admin.tag.repository.AdminTagJpaRepository;
 import com.grepp.smartwatcha.infra.jpa.entity.TagEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/resources/templates/admin/movie/list.html
+++ b/backend/src/main/resources/templates/admin/movie/list.html
@@ -274,6 +274,45 @@
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
       transform: scale(0.98);
     }
+
+    .star-rating-fixed {
+      display: flex;
+      gap: 2px;
+      font-size: 1.0rem;
+    }
+
+    .star {
+      position: relative;
+      width: 1.2rem;
+      height: 1.2rem;
+    }
+
+    .star-icon {
+      position: absolute;
+      color: #ccc; /* 빈 별 */
+      z-index: 0;
+    }
+
+    .star-fill {
+      position: absolute;
+      color: lightgoldenrodyellow; /* 채워진 별 */
+      z-index: 1;
+      overflow: hidden;
+      display: inline-block;
+      width: 100%; /* 기본 full */
+    }
+
+    .star.empty .star-fill {
+      width: 0;
+    }
+
+    .star.half .star-fill {
+      width: 50%;
+    }
+
+    .star.full .star-fill {
+      width: 100%;
+    }
   </style>
 </head>
 <body>
@@ -439,12 +478,39 @@
                  style="background-color: #424242;">
               <form th:action="@{'/admin/movies/' + ${movie.id} + '/update'}" method="post">
                 <div class="modal-content">
-                  <div style="margin-bottom: 15px">
-                    <label style="color: white; font-weight: bold; font-size: 1.1rem;">Movie
-                      ID</label>
-                    <span th:text="${movie.id}"
-                          style="color: white; margin-left: 8px; font-weight: bold; font-size: 1.1rem; "></span>
+
+                  <!-- Movie -->
+                  <div style="margin-bottom: 12px;">
+                    <div style="font-weight: bold; font-size: 1.1rem; color: lightcoral;">
+                      Movie ID <span th:text="${movie.id}" style="margin-left: 6px;"></span>
+                    </div>
+
+                    <!-- Avg Rating -->
+                    <div class="star-rating-fixed" style="margin-top: 5px">
+                      <span style="font-weight: 500; font-style: italic; color: lightyellow;">− Avg Rating :</span>
+                      <div class="star"
+                           th:each="i : ${#numbers.sequence(1, 5)}"
+                           th:classappend="${avgRatingMap[movie.id] >= i ? 'full' : (avgRatingMap[movie.id] >= i - 0.5 ? 'half' : 'empty')}">
+                        <span class="star-icon">☆</span>
+                        <span class="star-fill">★</span>
+                      </div>
+                      <span th:if="${avgRatingMap[movie.id] != null}"
+                            th:text="|(${#numbers.formatDecimal(avgRatingMap[movie.id], 1, 1)})|"
+                            style="font-style: italic; font-weight: 500; color: lightyellow;"></span>
+                    </div>
                   </div>
+
+                  <!-- User Tag -->
+                  <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; max-width: 100%;">
+                    <span th:if="${tagStatsMap[movie.id] != null}">
+                        <span th:each="tag : ${tagStatsMap[movie.id]}" class="chip"
+                              style="background-color: grey; color: white; font-size: 0.85rem; margin: 3px; border-radius: 16px;"
+                              th:text="${tag.tagName + ' [' + tag.count + ']'}"></span>
+                    </span>
+                    <span th:if="${tagStatsMap[movie.id] == null}" style="color: lightsteelblue; font-weight: 500; font-style: italic;">- No tags found.</span>
+                  </div>
+
+                  <!-- Poster -->
                   <div style="display: flex; gap: 2rem; align-items: flex-start;">
                     <div>
                       <img th:src="'https://image.tmdb.org/t/p/w500' + ${movie.poster}"
@@ -452,6 +518,8 @@
                            style="width: 120px; border-radius: 8px;"
                            onerror="this.onerror=null; this.src='/images/default.jpg';"/>
                     </div>
+
+                    <!-- Title -->
                     <div style="flex: 1;">
                       <div class="input-field input-wrapper"
                            style="display: flex; align-items: center; gap: 12px; margin-bottom: 16px; margin-top: 20px">
@@ -567,7 +635,6 @@
     </div>
   </div>
 
-
   <script>
     // 날짜 포맷 (flatpickr용)
     function formatDateToYMD(date) {
@@ -634,6 +701,7 @@
       document.querySelectorAll('.modal[id^="movieModal__"]').forEach(modal => {
         if (!M.Modal.getInstance(modal)) {
           const instance = M.Modal.init(modal, {
+
             onCloseEnd: () => {
               resetToOriginalValues(modal);
             }

--- a/backend/src/main/resources/templates/admin/tag/list.html
+++ b/backend/src/main/resources/templates/admin/tag/list.html
@@ -143,16 +143,49 @@
         <tr>
           <th>ID</th>
           <th>Tag Name</th>
+          <th>Usage Count</th>
+          <th>Usage</th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="tag : ${tags}">
           <td th:text="${tag.id}">1</td>
           <td th:text="${tag.name}">funny</td>
+          <td th:text="${tagUsageMap[tag.id] != null ? tagUsageMap[tag.id] : 0}">0</td>
+          <td>
+            <a th:href="'#tagUserModal__' + ${tag.id}" class="btn modal-btn modal-trigger waves-effect">View</a>
+
+            <!-- Modal -->
+            <div th:id="'tagUserModal__' + ${tag.id}" class="modal black-text" style="background-color: #424242">
+              <div class="modal-content">
+                <h5 style="color: white;" th:text="'🏷️  ' + ${tag.name}">Tag Usage</h5>
+                <table>
+                  <thead class="grey darken-3 white-text">
+                  <tr>
+                    <th style="color: white;">User</th>
+                    <th style="color: white;">Movie</th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  <tr th:each="usage : ${tagUsageDetailsMap[tag.id]?.userUsages}">
+                    <td style="color: white;" th:text="${usage.userName}">John</td>
+                    <td style="color: white;" th:text="${usage.movieTitle}">Inception</td>
+                  </tr>
+                  <tr th:if="${#lists.isEmpty(tagUsageDetailsMap[tag.id]?.userUsages)}">
+                    <td colspan="2">No usage found.</td>
+                  </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="modal-footer custom-modal-footer" style="display: flex; justify-content: flex-end; padding: 0 1rem; background-color: #424242;">
+                <a href="#!" class="modal-close btn-flat" style="color: white">Close</a>
+              </div>
+            </div>
+          </td>
         </tr>
 
         <tr th:if="${#lists.isEmpty(pageResponse.content)}">
-          <td colspan="2">No tag found.</td>
+          <td colspan="4">No tag found.</td>
         </tr>
         </tbody>
       </table>
@@ -178,6 +211,11 @@
     // X Button
     document.getElementById("resetBtn").addEventListener("click", function () {
       window.location.href = "/admin/tags";
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+      var elems = document.querySelectorAll('.modal');
+      var instances = M.Modal.init(elems);
     });
   </script>
 </section>


### PR DESCRIPTION
## 📌 과제 설명
관리자 페이지에서 태그 및 영화에 대한 통계 정보를 제공하는 기능을 구현했습니다.

- 태그가 영화에 얼마나 사용되었는지 통계를 제공 (태그 리스트 페이지)
- 영화 상세에서 해당 영화에 사용된 태그 + 해당 태그를 사용한 유저의 평균 평점을 제공

## 👩‍💻 요구 사항과 구현 내용

### 커밋 1: 태그별 영화 사용 통계 조회 기능 추가
- `AdminMovieTagJpaRepository`: 태그 사용 통계용 쿼리 추가
- `AdminMovieTagJpaService`: 통계 조회 서비스 로직 구현
- `AdminMovieController`: 영화 리스트 응답에 태그 통계 포함
- `AdminMovieListResponse`: 태그 통계 필드 추가
- `list.html` (영화): 화면에서 통계 표시

### 커밋 2: 영화 상세페이지 태그/유저 평점 통계 기능 추가
- `AdminMovieRatingJpaRepository`: 영화별 유저 평점 평균 조회 쿼리
- `AdminTagUserUsageDto`, `AdminTagUsageWithUsersDto`, `AdminTagUsageDto`: 응답 DTO 구성
- `AdminTagController`: 특정 태그 사용 유저 + 영화 응답 구현
- `list.html` (태그): 모달을 통해 상세 통계 표시

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점

