### PR TITLE
fix: 비활성화(탈퇴) 계정에 대한 로그인 차단 로직 추가

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/auth/CustomUserDetails.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/auth/CustomUserDetails.java
@@ -60,8 +60,8 @@ public class CustomUserDetails implements UserDetails {
 
   @Override
   public boolean isEnabled() {
-    return true;
-  } // 계정 활성화 여부
+    return user.getActivated(); // 계정 활성화 여부에 따라 로그인 가능 여부 결정
+  }
 
   public String getName() {
     return user.getName();


### PR DESCRIPTION
📌 과제 설명  
회원 탈퇴 후 DB상에서 activated가 false로 변경되어도 로그인이 가능한 문제를 해결하기 위해, Spring Security의 사용자 인증 로직을 수정

👩‍💻 요구 사항과 구현 내용
1. 문제점
- 회원 탈퇴 시 UserEntity.activated = false 로 비활성화되었음에도 로그인 가능
- 이는 Spring Security가 해당 상태를 확인하는 로직이 미구현되어있기 때문임을 확인

2. 원인
- CustomUserDetails 클래스에서 isEnabled() 메서드가 항상 true를 반환

3. 수정 내용
- CustomUserDetails.isEnabled() 메서드를 다음과 같이 수정:
  @Override
  public boolean isEnabled() {
      return user.getActivated(); // DB의 activated 값에 따라 로그인 가능 여부 결정
  }
- 이제 Spring Security가 로그인 시 해당 계정의 활성 여부를 자동으로 검사

4. 결과
- 탈퇴한 사용자 계정으로 더 이상 로그인 불가
- 보안과 사용자 상태 관리가 명확해짐

✅ PR 포인트
- UserEntity.activated 값을 Spring Security와 연결하여 인증 흐름 상에서 반영