### PR TITLE
fix: 회원가입 시 birth 값 누락으로 인한 인증 코드 검증 실패 해결

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/UserController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/UserController.java
@@ -204,6 +204,9 @@ public class UserController {
 
     @PostMapping("/signup/send-code")
     public String sendSignupVerificationCode(@ModelAttribute SignupRequestDto signupRequestDto, Model model) {
+        // 디버깅 로그 추가
+        log.info("sendSignupVerificationCode: name={}, email={}, phoneNumber={}, password={}", 
+            signupRequestDto.getName(), signupRequestDto.getEmail(), signupRequestDto.getPhoneNumber(), signupRequestDto.getPassword());
         try {
             userJpaService.sendSignupVerificationCode(signupRequestDto.getEmail());
             model.addAttribute("codeSent", true);
@@ -228,6 +231,20 @@ public class UserController {
     public String verifySignupCode(@ModelAttribute SignupRequestDto signupRequestDto, 
                                  @RequestParam String verificationCode,
                                  Model model, RedirectAttributes redirectAttributes) {
+        // 디버깅 로그
+        log.info("verifySignupCode: name={}, email={}, phoneNumber={}, password={}, birth={}", 
+            signupRequestDto.getName(), signupRequestDto.getEmail(), signupRequestDto.getPhoneNumber(), 
+            signupRequestDto.getPassword(), signupRequestDto.getBirth());
+
+        // 값이 하나라도 null이면 에러 안내
+        if (signupRequestDto.getName() == null || signupRequestDto.getEmail() == null || 
+            signupRequestDto.getPhoneNumber() == null || signupRequestDto.getPassword() == null ||
+            signupRequestDto.getBirth() == null) {
+            model.addAttribute("codeSent", true);
+            model.addAttribute("signupRequestDto", signupRequestDto);
+            model.addAttribute("error", "입력값이 누락되었습니다. 처음부터 다시 시도해 주세요.");
+            return "signup";
+        }
         try {
             boolean verified = userJpaService.verifyEmailCodeWithKotlinApi(signupRequestDto.getEmail(), verificationCode);
             if (verified) {

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/UserJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/UserJpaService.java
@@ -61,7 +61,18 @@ public class UserJpaService {
                 .filter(user -> !user.getActivated())
                 .orElse(null);
 
-        LocalDate birth = LocalDate.parse(requestDto.getBirth(), DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        // birth 값 null 체크
+        if (requestDto.getBirth() == null || requestDto.getBirth().trim().isEmpty()) {
+            throw new IllegalArgumentException("생년월일을 입력해주세요.");
+        }
+
+        LocalDate birth;
+        try {
+            birth = LocalDate.parse(requestDto.getBirth(), DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("생년월일 형식이 올바르지 않습니다. (예: 2000.04.20)");
+        }
+        
         int age = Period.between(birth, LocalDate.now()).getYears();
         boolean isAdult = age >= 19;
 

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -32,6 +32,6 @@ validation.code.required=Verification code is required
 validation.name.required=Name is required
 validation.phone.required=Phone number is required
 validation.phone.format=Invalid phone number format
-validation.password.format=Password must be at least 8 characters and contain letters, numbers, and special characters
+validation.password.format=Password must be at least 8 characters and contain letters, numbers, and special characters 
 validation.password.required=New password is required
 validation.password.confirm=Please confirm your new password 

--- a/backend/src/main/resources/templates/signup.html
+++ b/backend/src/main/resources/templates/signup.html
@@ -116,6 +116,7 @@
                             <input type="hidden" name="name" th:value="${signupRequestDto.name}">
                             <input type="hidden" name="email" th:value="${signupRequestDto.email}">
                             <input type="hidden" name="phoneNumber" th:value="${signupRequestDto.phoneNumber}">
+                            <input type="hidden" name="birth" th:value="${signupRequestDto.birth}">
                             <input type="hidden" name="password" th:value="${signupRequestDto.password}">
                             <input type="hidden" name="confirmPassword" th:value="${signupRequestDto.confirmPassword}">
                             <div class="input-field" style="display: flex; align-items: center;">
@@ -169,7 +170,7 @@
             var form = document.createElement('form');
             form.method = 'POST';
             form.action = '/user/signup/send-code';
-            ['name','email','phoneNumber','password','confirmPassword'].forEach(function(field) {
+            ['name','email','phoneNumber','birth','password','confirmPassword'].forEach(function(field) {
                 var input = document.createElement('input');
                 input.type = 'hidden';
                 input.name = field;


### PR DESCRIPTION
📌 과제 설명
회원가입 단계에서 이메일 인증 검증 중 birth 값 누락으로 인해 500 에러가 발생하는 문제를 해결

👩‍💻 요구 사항과 구현 내용
	1.	문제 배경
	•	회원가입 → 인증코드 발송 → 인증코드 검증 단계에서 birth 값 누락으로 인해 백엔드에서 LocalDate.parse() 호출 시 NullPointerException 발생
	2.	구현 사항
	•	Controller : verifySignupCode()에서 birth null 체크 추가
	•	Service: signup()에서 birth null/빈 문자열 체크 및 예외 처리 로직 추가
	•	View: signup.html에 birth 값을 hidden input으로 추가하여 인증 단계까지 전달되도록 수정
	•	JS 수정 : birth 필드가 form submit 시 누락되지 않도록 JS 로직 수정

✅ PR 포인트
	•	기존 JS 기반 이메일 인증 흐름 내에서 발생하던 필드 누락 문제 해결
	•	백엔드에서는 모든 입력값에 대해 사전 검증 + 예외 처리 적용